### PR TITLE
fix(doc-layout): improve line-height for typography readability

### DIFF
--- a/doc-layout/src/template.js
+++ b/doc-layout/src/template.js
@@ -20,6 +20,9 @@ export const docLayoutTemplate = (content, context) => html`
         justify-content: unset;
       }
     }
+    .story_padded {
+      line-height: initial;
+    }
     .preview-story .story_padded {
       background-color: var(--simba-bg-color);
       color: var(--simba-text-color);
@@ -36,9 +39,6 @@ export const docLayoutTemplate = (content, context) => html`
     .markdown-body tt {
       background-color: transparent;
       border: none;
-    }
-    .prose {
-      line-height: initial;
     }
   </style>
   <mdjs-layout


### PR DESCRIPTION
Non-standard `line-height` is set in typography's `prose` for readability (vertical rhythm)

I think your idea to fix it for demos was to reset it inside the MDJS-story context, which can be achieved without reseting it for the entire typography. This PR fixes that.

I hope you didn't want to reset line-height for other things, like other dockit-like components, then ofc such naive fix won't work, but we need to handle this correctly, because many things don't look good without the prose's original line-height.

![image](https://user-images.githubusercontent.com/137844/147831058-ef0316a3-21c0-4e6e-858b-4d6ad16aaed4.png)
